### PR TITLE
Updated to work with Spring Boot 3 and Jakarta EE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-01-31
+- Breaking changes: This version requires Java 17 and Spring Boot 3.0.2+
+  - Due to the switch from Java EE to Jakarta EE, this version of the library is incompatible with Spring Boot versions prior to 3.0.0.
+  - Spring Boot 3.x also requires Java 17, so Java 11 can therefore no longer be supported.
+- Added ability to render a custom error result, in case of missing / invalid API Key.
+- Do not include `lombok` as a runtime dependency, its scope should have been `provided`. This is now fixed.
+- (unit test dependencies) Replaced deprecated `httpclient` with `httpclient5`.
+
 ## [1.0.0] - 2021-12-08
 - Initial release
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ A library to easily configure API Key authentication in (parts of) your Spring B
 - Configurable header name
 - Configurable filter placement in the FilterChain
 
+## Requirements
+- Java 17 and Spring Boot 3.0.0+ (use version 1.0.0 of this library if still using Spring Boot 2.x)
+- Spring Security
+- Spring Web
+
 ## Setting up API Key authentication
 
 - You must have the following components in your application:
@@ -30,7 +35,7 @@ A library to easily configure API Key authentication in (parts of) your Spring B
     <dependency>
         <groupId>nl.42</groupId>
         <artifactId>api-key-authentication</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -43,16 +48,16 @@ A library to easily configure API Key authentication in (parts of) your Spring B
 </dependencies>
 ```
 
-- Create a class annotated by `@Configuration` and extending `WebSecurityConfigurerAdapter` and add it to your app:
+- Create a class annotated by `@Configuration` which defines a `SecurityFilterChain` bean. Add it to your app:
  
 ```java
 @Configuration
 @EnableWebSecurity
-public class ApiKeyConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyConfig {
 
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     // You can easily configure this library using the Builder...
     // ... or you can create your very own implementation of ApiKeyAuthenticationConfiguration
     ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder() 
@@ -65,6 +70,8 @@ public class ApiKeyConfig extends WebSecurityConfigurerAdapter {
             .build();
 
     ApiKeyAuthenticationConfigurer.configure(config, http);
+    
+    return http.build();
   }
 }
 ```
@@ -77,16 +84,18 @@ The default header name will be `x-api-key`, but you can override it as followin
  ```java
 @Configuration
 @EnableWebSecurity
-public class ApiKeyConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyConfig {
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
             .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
             .headerName("my-awesome-api-key-header-name")
             .build();
 
     ApiKeyAuthenticationConfigurer.configure(config, http);
+    
+    return http.build();
   }
 }
  ```
@@ -97,16 +106,18 @@ By default, all endpoints will be secured. You can either use a String-based ANT
  ```java
 @Configuration
 @EnableWebSecurity
-public class ApiKeyConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyConfig {
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
             .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
             .requestMatcher(new OrRequestMatcher(new AntPathRequestMatcher("/public-api/v1/**"), new AntPathRequestMatcher("/public-api/v2/**")))
             .build();
 
     ApiKeyAuthenticationConfigurer.configure(config, http);
+    
+    return http.build();
   }
 }
  ```
@@ -121,10 +132,10 @@ either use the `addFilterBeforeClass` and `addFilterAfterClass` methods of the B
  ```java
 @Configuration
 @EnableWebSecurity
-public class ApiKeyConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyConfig {
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
             .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
             .addFilterBeforeClass(BasicAuthenticationFilter.class)
@@ -132,6 +143,8 @@ public class ApiKeyConfig extends WebSecurityConfigurerAdapter {
             .build();
 
     ApiKeyAuthenticationConfigurer.configure(config, http);
+    
+    return http.build();
   }
 }
  ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>nl.42</groupId>
     <artifactId>api-key-authentication</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 API Key Authentication</name>
     <description>Helper to configure API Key authentication in Spring applications</description>
@@ -52,15 +52,23 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot.version>2.6.1</spring-boot.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
-        <dependency-check-maven-plugin.version>6.5.0</dependency-check-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <!-- main scope versions -->
+        <spring-boot.version>3.0.2</spring-boot.version>
+        <lombok.version>1.18.24</lombok.version>
+
+        <!-- test scope versions -->
+        <httpclient5.version>5.2.1</httpclient5.version>
+        <json-path.version>2.7.0</json-path.version>
+
+        <!-- plugin versions -->
+        <dependency-check-maven-plugin.version>8.0.2</dependency-check-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -90,6 +98,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- TEST dependencies -->
@@ -106,6 +116,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
+            <version>${json-path.version}</version>
             <scope>test</scope>
         </dependency>
         <!--
@@ -114,8 +125,9 @@
             checks.
         -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfiguration.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfiguration.java
@@ -2,7 +2,7 @@ package nl._42.apikeyauthentication.autoconfigure;
 
 import java.util.Collection;
 
-import javax.servlet.Filter;
+import jakarta.servlet.Filter;
 
 import org.springframework.security.web.util.matcher.RequestMatcher;
 

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurationBuilder.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurationBuilder.java
@@ -4,7 +4,7 @@ package nl._42.apikeyauthentication.autoconfigure;
 import java.util.Collection;
 import java.util.Objects;
 
-import javax.servlet.Filter;
+import jakarta.servlet.Filter;
 
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurer.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurer.java
@@ -22,7 +22,7 @@ public class ApiKeyAuthenticationConfigurer {
          * We don't need to create sessions, all the requests must provide
          * a valid API Key, so we recheck each time
          */
-        SessionManagementConfigurer<HttpSecurity> configurer = http.requestMatcher(configuration.getRequestMatcher())
+        SessionManagementConfigurer<HttpSecurity> configurer = http.securityMatcher(configuration.getRequestMatcher())
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
@@ -49,7 +49,7 @@ public class ApiKeyAuthenticationConfigurer {
          */
         httpWithFilter
                 .csrf().disable()
-                .authorizeRequests().anyRequest().authenticated();
+                .authorizeHttpRequests().anyRequest().authenticated();
     }
 
 }

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyAuthenticationManager.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyAuthenticationManager.java
@@ -1,7 +1,6 @@
 package nl._42.apikeyauthentication.autoconfigure.authentication;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -22,7 +21,7 @@ public class ApiKeyAuthenticationManager implements AuthenticationManager {
             throw new BadCredentialsException("The API key was not found or not the expected value.");
         }
 
-        String key = ((ApiKeyPrincipal) authentication.getPrincipal()).getApiKey();
+        String key = ((ApiKeyPrincipal) authentication.getPrincipal()).apiKey();
         if (!authorizedApiKeys.contains(key)) {
             throw new BadCredentialsException("The API key was not found or not the expected value.");
         }

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyPrincipal.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyPrincipal.java
@@ -1,14 +1,5 @@
 package nl._42.apikeyauthentication.autoconfigure.authentication;
 
-public class ApiKeyPrincipal {
+public record ApiKeyPrincipal(String apiKey) {
 
-    private final String apiKey;
-
-    public ApiKeyPrincipal(String apiKey) {
-        this.apiKey = apiKey;
-    }
-
-    public String getApiKey() {
-        return apiKey;
-    }
 }

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilter.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilter.java
@@ -1,6 +1,6 @@
 package nl._42.apikeyauthentication.autoconfigure.authentication;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/AbstractSpringTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/AbstractSpringTest.java
@@ -2,13 +2,13 @@ package nl._42.apikeyauthentication.autoconfigure;
 
 import java.util.Collections;
 
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.platform.commons.util.StringUtils;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyPrincipalTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyPrincipalTest.java
@@ -8,6 +8,6 @@ class ApiKeyPrincipalTest {
 
     @Test
     void getApiKey() {
-        assertEquals("test", new ApiKeyPrincipal("test").getApiKey());
+        assertEquals("test", new ApiKeyPrincipal("test").apiKey());
     }
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilterTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilterTest.java
@@ -49,7 +49,7 @@ class ApiKeyRequestFilterTest {
 
             assertTrue(principal instanceof ApiKeyPrincipal);
 
-            assertEquals(apiKey, ((ApiKeyPrincipal)principal).getApiKey());
+            assertEquals(apiKey, ((ApiKeyPrincipal)principal).apiKey());
         }
     }
 

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyCustomHeaderNameConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyCustomHeaderNameConfig.java
@@ -6,29 +6,32 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @Profile("api-key-custom-header-name")
 @EnableWebSecurity
-public class ApiKeyCustomHeaderNameConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyCustomHeaderNameConfig {
 
     public static final String HEADER_NAME = "foobar";
 
     public static final String ALLOWED_KEY_1 = "custom-header-1234567890";
     public static final String ALLOWED_KEY_2 = "custom-header-abcdefghij";
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
                 .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
                 .headerName(HEADER_NAME)
                 .build();
 
         ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
     }
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyOnAllEndpointsConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyOnAllEndpointsConfig.java
@@ -6,26 +6,29 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @Profile("api-key-all-endpoints")
 @EnableWebSecurity
-public class ApiKeyOnAllEndpointsConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyOnAllEndpointsConfig {
 
     public static final String ALLOWED_KEY_1 = "all-1234567890";
     public static final String ALLOWED_KEY_2 = "all-abcdefghij";
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
                 .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
                 .build();
 
         ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
     }
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyOnAntPatternConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyOnAntPatternConfig.java
@@ -6,27 +6,30 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @Profile("api-key-ant-pattern")
 @EnableWebSecurity
-public class ApiKeyOnAntPatternConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyOnAntPatternConfig {
 
     public static final String ALLOWED_KEY_1 = "public-1234567890";
     public static final String ALLOWED_KEY_2 = "public-abcdefghij";
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
                 .antPattern("/public-api/**")
                 .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
                 .build();
 
         ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
     }
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyOnCustomRequestMatcherConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/ApiKeyOnCustomRequestMatcherConfig.java
@@ -6,24 +6,25 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 
 @Configuration
 @Profile("api-key-custom-request-matcher")
 @EnableWebSecurity
-public class ApiKeyOnCustomRequestMatcherConfig extends WebSecurityConfigurerAdapter {
+public class ApiKeyOnCustomRequestMatcherConfig {
 
     public static final String ALLOWED_KEY_1 = "custom-request-matcher-1234567890";
     public static final String ALLOWED_KEY_2 = "custom-request-matcher-abcdefghij";
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
                 .antPattern("/private-api/**") // Will be ignored, the requestMatcher takes precedence over a String antPattern.
                 .requestMatcher(new OrRequestMatcher(new AntPathRequestMatcher("/public-api/v1/hello"), new AntPathRequestMatcher("/public-api/v1/goodbye")))
@@ -31,5 +32,7 @@ public class ApiKeyOnCustomRequestMatcherConfig extends WebSecurityConfigurerAda
                 .build();
 
         ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
     }
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/FilterPositioningAfterConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/FilterPositioningAfterConfig.java
@@ -7,22 +7,23 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @Profile("api-key-filter-positioning-after")
 @EnableWebSecurity
-public class FilterPositioningAfterConfig extends WebSecurityConfigurerAdapter {
+public class FilterPositioningAfterConfig {
 
     public static final String ALLOWED_KEY = "filter-position-after-1234567890";
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http = http.addFilterBefore(new FooFilter(), BasicAuthenticationFilter.class);
 
         ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
@@ -30,6 +31,8 @@ public class FilterPositioningAfterConfig extends WebSecurityConfigurerAdapter {
                 .addFilterAfterClass(FooFilter.class)
                 .build();
         ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
     }
 
 

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/FilterPositioningBeforeConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/FilterPositioningBeforeConfig.java
@@ -6,22 +6,23 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @Profile("api-key-filter-positioning-before")
 @EnableWebSecurity
-public class FilterPositioningBeforeConfig extends WebSecurityConfigurerAdapter {
+public class FilterPositioningBeforeConfig {
 
     public static final String ALLOWED_KEY = "filter-position-before-1234567890";
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http = http.addFilterBefore(new FooFilter(), BasicAuthenticationFilter.class);
 
         ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
@@ -29,6 +30,8 @@ public class FilterPositioningBeforeConfig extends WebSecurityConfigurerAdapter 
                 .addFilterBeforeClass(FooFilter.class)
                 .build();
         ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
     }
 
 

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/FooFilter.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/FooFilter.java
@@ -3,11 +3,11 @@ package nl._42.apikeyauthentication.autoconfigure.test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import nl._42.apikeyauthentication.autoconfigure.authentication.ApiKeyPrincipal;
 
@@ -27,7 +27,7 @@ public class FooFilter implements Filter {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth instanceof PreAuthenticatedAuthenticationToken) {
-            apiKey = ((ApiKeyPrincipal)auth.getPrincipal()).getApiKey();
+            apiKey = ((ApiKeyPrincipal)auth.getPrincipal()).apiKey();
         }
         httpServletResponse.getOutputStream().write(("I AM A TEAPOT AND AM USING KEY " + apiKey + " :D").getBytes(StandardCharsets.UTF_8));
     }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/MissingFilterPositioningConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/MissingFilterPositioningConfig.java
@@ -6,24 +6,25 @@ import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurati
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
 import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @Profile("api-key-filter-positioning-missing")
 @EnableWebSecurity
-public class MissingFilterPositioningConfig extends WebSecurityConfigurerAdapter {
+public class MissingFilterPositioningConfig {
 
     public static final String ALLOWED_KEY = "filter-position-missing-1234567890";
 
     private static IllegalArgumentException exception;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         exception = null;
         http = http.addFilterBefore(new FooFilter(), BasicAuthenticationFilter.class);
 
@@ -38,6 +39,8 @@ public class MissingFilterPositioningConfig extends WebSecurityConfigurerAdapter
         } catch (IllegalArgumentException e) {
             exception = e;
         }
+
+        return http.build();
     }
 
     public static IllegalArgumentException getException() {


### PR DESCRIPTION
Updated the library to work with Spring Boot 3, which uses Jakarta EE instead of Java EE 8.

This caused several imports to change, making this upgrade a breaking change which is incompatible with Spring Boot 2.x.

Also updated various dependencies, and made lombok a provided dependency as it should have been.