### PR TITLE
fix!: Return HTTP 401 for invalid or missing API Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Breaking changes:
+  - The filter now returns HTTP 401 'Unauthorized' instead of HTTP 403 'Forbidden' when no API Key or an invalid API Key is provided.
+
 ## [2.0.0] - 2023-01-31
 - Breaking changes: This version requires Java 17 and Spring Boot 3.0.2+
   - Due to the switch from Java EE to Jakarta EE, this version of the library is incompatible with Spring Boot versions prior to 3.0.0.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,34 @@ public class ApiKeyConfig {
 }
  ```
 
+### Using a custom response code for failed authentications
+By default, your security settings will be configured to return HTTP 401 'Unauthorized' for requests that fail
+to authenticate using an API Key.
+
+You can customize this to return a different HTTP status code or error handler.
+ 
+ ```java
+@Configuration
+@EnableWebSecurity
+public class ApiKeyConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
+            .authorizedApiKeys(Set.of(ALLOWED_KEY_1, ALLOWED_KEY_2))
+            // Option 1: custom authenticationFailureEntryPoint which sets Http 402 'Payment Required' as status.
+            .authenticationFailureEntryPoint(new HttpStatusEntryPoint(HttpStatus.PAYMENT_REQUIRED))
+            // Option 2: If you want to keep the default settings of Spring (HTTP 403 'Forbidden'), explicitly set this to null:
+            .authenticationFailureEntryPoint(null)
+            .build();
+
+    ApiKeyAuthenticationConfigurer.configure(config, http);
+    
+    return http.build();
+  }
+}
+ ```
+
 ### Advanced request matching
 By default, all endpoints will be secured. You can either use a String-based ANT Pattern or a `RequestMatcher` to customize which endpoints to protect.
  

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfiguration.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfiguration.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 
 import jakarta.servlet.Filter;
 
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
@@ -40,4 +41,10 @@ public interface ApiKeyAuthenticationConfiguration {
      * @return Returns a class to insert the filter before in the filterChain.
      */
     Class<? extends Filter> getAddFilterAfterClass();
+
+    /**
+     * {@link AuthenticationEntryPoint} which handles failed authentications.
+     * @return Returns a {@link AuthenticationEntryPoint} which will be used for failed authentications.
+     */
+    AuthenticationEntryPoint getAuthenticationFailureEntryPoint();
 }

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurationBuilder.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurationBuilder.java
@@ -9,6 +9,9 @@ import jakarta.servlet.Filter;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -31,6 +34,9 @@ public class ApiKeyAuthenticationConfigurationBuilder implements ApiKeyAuthentic
     private final RequestMatcher requestMatcher = DEFAULT_REQUEST_MATCHER;
 
     private final Collection<String> authorizedApiKeys;
+
+    @Builder.Default
+    private final AuthenticationEntryPoint authenticationFailureEntryPoint = new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED);
 
     @Builder.Default
     private final Class<? extends Filter> addFilterBeforeClass = BasicAuthenticationFilter.class;
@@ -92,5 +98,19 @@ public class ApiKeyAuthenticationConfigurationBuilder implements ApiKeyAuthentic
     @Override
     public Class<? extends Filter> getAddFilterAfterClass() {
         return addFilterAfterClass;
+    }
+
+    /**
+     * Specify the {@link AuthenticationEntryPoint} which handles failed authentications.
+     * By default, we return HTTP 401 'Unauthorized' via {@link HttpStatusEntryPoint}.
+     * This best matches the situation for incorrect API Keys, which are unauthorized to use the application.
+     * You can override this method to specify your own {@link AuthenticationEntryPoint}, such as for another
+     * HTTP status code or for custom error handling.
+     * You can also explicitly set this to 'null' to use the default authentication failure handler of Spring.
+     * @return Returns the {@link AuthenticationEntryPoint} to use for failed authentications.
+     */
+    @Override
+    public AuthenticationEntryPoint getAuthenticationFailureEntryPoint() {
+        return authenticationFailureEntryPoint;
     }
 }

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurer.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurer.java
@@ -6,6 +6,7 @@ import nl._42.apikeyauthentication.autoconfigure.authentication.ApiKeyRequestFil
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 
 public class ApiKeyAuthenticationConfigurer {
 
@@ -45,7 +46,18 @@ public class ApiKeyAuthenticationConfigurer {
         }
 
         /*
-         * CSRF interferes with POST / PUT / DELETE requests securecd by the API Key. Therefore, it must be disabled.
+         * Sets the authenticationEntryPoint to handle requests where no, or an invalid API Key has been specified.
+         * If null, we do not change the default configuration of Spring.
+         */
+        AuthenticationEntryPoint authenticationFailureEntryPoint = configuration.getAuthenticationFailureEntryPoint();
+        if (authenticationFailureEntryPoint != null) {
+            httpWithFilter.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
+                    .authenticationEntryPoint(authenticationFailureEntryPoint)
+            );
+        }
+
+        /*
+         * CSRF interferes with POST / PUT / DELETE requests secured by the API Key. Therefore, it must be disabled.
          */
         httpWithFilter
                 .csrf().disable()

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyAuthenticationManager.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyAuthenticationManager.java
@@ -22,7 +22,7 @@ public class ApiKeyAuthenticationManager implements AuthenticationManager {
         }
 
         String key = ((ApiKeyPrincipal) authentication.getPrincipal()).apiKey();
-        if (!authorizedApiKeys.contains(key)) {
+        if (!authorizedApiKeys.contains(key != null ? key : "")) {
             throw new BadCredentialsException("The API key was not found or not the expected value.");
         }
 

--- a/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilter.java
+++ b/src/main/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilter.java
@@ -18,11 +18,7 @@ public class ApiKeyRequestFilter extends AbstractPreAuthenticatedProcessingFilte
 
     @Override
     protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
-        String apiKeyValue = request.getHeader(headerName);
-        if (apiKeyValue == null || apiKeyValue.equals("")) {
-            return null;
-        }
-        return new ApiKeyPrincipal(apiKeyValue);
+        return new ApiKeyPrincipal(request.getHeader(headerName));
     }
 
     @Override

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurerTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyAuthenticationConfigurerTest.java
@@ -12,9 +12,11 @@ import nl._42.apikeyauthentication.autoconfigure.test.ApiKeyCustomHeaderNameConf
 import nl._42.apikeyauthentication.autoconfigure.test.ApiKeyOnAllEndpointsConfig;
 import nl._42.apikeyauthentication.autoconfigure.test.ApiKeyOnAntPatternConfig;
 import nl._42.apikeyauthentication.autoconfigure.test.ApiKeyOnCustomRequestMatcherConfig;
+import nl._42.apikeyauthentication.autoconfigure.test.CustomAuthenticationEntryPointConfig;
 import nl._42.apikeyauthentication.autoconfigure.test.FilterPositioningAfterConfig;
 import nl._42.apikeyauthentication.autoconfigure.test.FilterPositioningBeforeConfig;
 import nl._42.apikeyauthentication.autoconfigure.test.MissingFilterPositioningConfig;
+import nl._42.apikeyauthentication.autoconfigure.test.NullAuthenticationEntryPointConfig;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,22 +39,22 @@ public class ApiKeyAuthenticationConfigurerTest {
         void shouldEnableOnAllEndpoints() {
             RestTemplate allowedRestTemplate1 = buildRestTemplate(ApiKeyOnAllEndpointsConfig.ALLOWED_KEY_1);
             RestTemplate allowedRestTemplate2 = buildRestTemplate(ApiKeyOnAllEndpointsConfig.ALLOWED_KEY_2);
-            RestTemplate forbiddenTemplate = buildRestTemplate("foo");
+            RestTemplate unauthorizedTemplate = buildRestTemplate("foo");
 
             // Both configured keys should be allowed
             HttpEntity<Map<String, Object>> publicApiResult1 = allowedRestTemplate1.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
             HttpEntity<Map<String, Object>> publicApiResult2 = allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
 
-            // Foo key should be forbidden
-            HttpClientErrorException errorExceptionForbidden1 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
-            HttpClientErrorException errorExceptionForbidden2 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, List.class));
-            HttpClientErrorException errorExceptionForbidden3 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
+            // Foo key should be unauthorized
+            HttpClientErrorException errorExceptionUnauthorized1 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            HttpClientErrorException errorExceptionUnauthorized2 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, List.class));
+            HttpClientErrorException errorExceptionUnauthorized3 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
 
             assertEquals("hi", Objects.requireNonNull(publicApiResult1.getBody()).get("message"));
             assertEquals("hi", Objects.requireNonNull(publicApiResult2.getBody()).get("message"));
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden1.getStatusCode());
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden2.getStatusCode());
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden3.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized1.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized2.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized3.getStatusCode());
         }
     }
 
@@ -64,7 +66,7 @@ public class ApiKeyAuthenticationConfigurerTest {
         void shouldEnableOnAllEndpoints() {
             RestTemplate allowedRestTemplate1 = buildRestTemplate(ApiKeyCustomHeaderNameConfig.ALLOWED_KEY_1);
             RestTemplate allowedRestTemplate2 = buildRestTemplate(ApiKeyCustomHeaderNameConfig.ALLOWED_KEY_2);
-            RestTemplate forbiddenTemplate = buildRestTemplate("foo");
+            RestTemplate unauthorizedTemplate = buildRestTemplate("foo");
 
             // Both configured keys should be allowed if using the correct header name
             HttpHeaders key1Headers = new HttpHeaders();
@@ -81,20 +83,20 @@ public class ApiKeyAuthenticationConfigurerTest {
             HttpEntity<Map<String, Object>> publicApiResult1 = allowedRestTemplate1.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, httpEntityKey1, ParameterizedTypeReference.forType(Map.class));
             HttpEntity<Map<String, Object>> publicApiResult2 = allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, httpEntityKey2, ParameterizedTypeReference.forType(Map.class));
 
-            // Foo key should be forbidden even if using the correct header name.
-            HttpClientErrorException errorExceptionForbidden1 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, httpEntityKeyFoo, Map.class));
+            // Foo key should be unauthorized even if using the correct header name.
+            HttpClientErrorException errorExceptionUnauthorized1 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, httpEntityKeyFoo, Map.class));
 
-            // All keys should be forbidden if not using the correct header name (the default is x-api-key, by specifying a null httpEntity this will be used).
-            HttpClientErrorException errorExceptionForbidden2 = assertThrows(HttpClientErrorException.class, () -> allowedRestTemplate1.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
-            HttpClientErrorException errorExceptionForbidden3 = assertThrows(HttpClientErrorException.class, () -> allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
-            HttpClientErrorException errorExceptionForbidden4 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            // All keys should be unauthorized if not using the correct header name (the default is x-api-key, by specifying a null httpEntity this will be used).
+            HttpClientErrorException errorExceptionUnauthorized2 = assertThrows(HttpClientErrorException.class, () -> allowedRestTemplate1.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            HttpClientErrorException errorExceptionUnauthorized3 = assertThrows(HttpClientErrorException.class, () -> allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            HttpClientErrorException errorExceptionUnauthorized4 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
 
             assertEquals("hi", Objects.requireNonNull(publicApiResult1.getBody()).get("message"));
             assertEquals("hi", Objects.requireNonNull(publicApiResult2.getBody()).get("message"));
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden1.getStatusCode());
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden2.getStatusCode());
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden3.getStatusCode());
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden4.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized1.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized2.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized3.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized4.getStatusCode());
         }
     }
 
@@ -106,7 +108,7 @@ public class ApiKeyAuthenticationConfigurerTest {
         public void shouldConfigureSecurity_withAntPattern() {
             RestTemplate allowedRestTemplate1 = buildRestTemplate(ApiKeyOnAntPatternConfig.ALLOWED_KEY_1);
             RestTemplate allowedRestTemplate2 = buildRestTemplate(ApiKeyOnAntPatternConfig.ALLOWED_KEY_2);
-            RestTemplate forbiddenTemplate = buildRestTemplate("foo");
+            RestTemplate unauthorizedTemplate = buildRestTemplate("foo");
 
             // Both configured keys should be allowed
             HttpEntity<Map<String, Object>> publicApiResult1 = allowedRestTemplate1.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
@@ -114,12 +116,12 @@ public class ApiKeyAuthenticationConfigurerTest {
             HttpEntity<Map<String, Object>> publicApiResult3 = allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/goodbye", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
             HttpEntity<Map<String, Object>> publicApiResult4 = allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/sleep-well", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
 
-            // Foo key should be forbidden on endpoints matching the ant pattern (/public-api/**)
-            HttpClientErrorException errorExceptionForbidden = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            // Foo key should be unauthorized on endpoints matching the ant pattern (/public-api/**)
+            HttpClientErrorException errorExceptionUnauthorized = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
 
-            // Foo key should NOT be forbidden on other endpoints than /public-api, since no security config exists for those.
-            HttpEntity<List<Map<String, Object>>> privateApiResult = forbiddenTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, ParameterizedTypeReference.forType(List.class));
-            HttpClientErrorException errorExceptionNotFound = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
+            // Foo key should NOT be unauthorized on other endpoints than /public-api, since no security config exists for those.
+            HttpEntity<List<Map<String, Object>>> privateApiResult = unauthorizedTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, ParameterizedTypeReference.forType(List.class));
+            HttpClientErrorException errorExceptionNotFound = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
 
             assertEquals("hi", Objects.requireNonNull(publicApiResult1.getBody()).get("message"));
             assertEquals("hi", Objects.requireNonNull(publicApiResult2.getBody()).get("message"));
@@ -127,7 +129,7 @@ public class ApiKeyAuthenticationConfigurerTest {
             assertEquals("sleep well", Objects.requireNonNull(publicApiResult4.getBody()).get("message"));
             assertEquals("John", Objects.requireNonNull(privateApiResult.getBody()).get(0).get("firstName"));
             assertEquals("Astley", Objects.requireNonNull(privateApiResult.getBody()).get(1).get("lastName"));
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized.getStatusCode());
             assertEquals(HttpStatus.NOT_FOUND, errorExceptionNotFound.getStatusCode());
         }
     }
@@ -140,7 +142,7 @@ public class ApiKeyAuthenticationConfigurerTest {
         public void shouldConfigureSecurity_withAntPattern() {
             RestTemplate allowedRestTemplate1 = buildRestTemplate(ApiKeyOnCustomRequestMatcherConfig.ALLOWED_KEY_1);
             RestTemplate allowedRestTemplate2 = buildRestTemplate(ApiKeyOnCustomRequestMatcherConfig.ALLOWED_KEY_2);
-            RestTemplate forbiddenTemplate = buildRestTemplate("foo");
+            RestTemplate unauthorizedTemplate = buildRestTemplate("foo");
 
             // Both configured keys should be allowed
             HttpEntity<Map<String, Object>> publicApiResult1 = allowedRestTemplate1.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
@@ -148,20 +150,20 @@ public class ApiKeyAuthenticationConfigurerTest {
             HttpEntity<Map<String, Object>> publicApiResult3 = allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/goodbye", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
             HttpEntity<Map<String, Object>> publicApiResult4 = allowedRestTemplate2.exchange(baseUrl + "/public-api/v1/sleep-well", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
 
-            // Foo key should be forbidden on endpoints matching the requestMatcher (/public-api/hello, /public-api/goodbye)
-            HttpClientErrorException errorExceptionForbidden1 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
-            HttpClientErrorException errorExceptionForbidden2 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/goodbye", HttpMethod.GET, null, Map.class));
+            // Foo key should be unauthorized on endpoints matching the requestMatcher (/public-api/hello, /public-api/goodbye)
+            HttpClientErrorException errorExceptionUnauthorized1 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            HttpClientErrorException errorExceptionUnauthorized2 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/goodbye", HttpMethod.GET, null, Map.class));
 
-            // Foo key should NOT be forbidden on /public-api/sleep-well, since it is not matched by the requestMatcher.
-            HttpEntity<Map<String, Object>> publicApiResult5 = forbiddenTemplate.exchange(baseUrl + "/public-api/v1/sleep-well", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
+            // Foo key should NOT be unauthorized on /public-api/sleep-well, since it is not matched by the requestMatcher.
+            HttpEntity<Map<String, Object>> publicApiResult5 = unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/sleep-well", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
 
             assertEquals("hi", Objects.requireNonNull(publicApiResult1.getBody()).get("message"));
             assertEquals("hi", Objects.requireNonNull(publicApiResult2.getBody()).get("message"));
             assertEquals("goodbye", Objects.requireNonNull(publicApiResult3.getBody()).get("message"));
             assertEquals("sleep well", Objects.requireNonNull(publicApiResult4.getBody()).get("message"));
             assertEquals("sleep well", Objects.requireNonNull(publicApiResult5.getBody()).get("message"));
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden1.getStatusCode());
-            assertEquals(HttpStatus.FORBIDDEN, errorExceptionForbidden2.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized1.getStatusCode());
+            assertEquals(HttpStatus.UNAUTHORIZED, errorExceptionUnauthorized2.getStatusCode());
         }
     }
 
@@ -172,24 +174,24 @@ public class ApiKeyAuthenticationConfigurerTest {
         @DisplayName("should enable API Key authentication on all endpoints, since the filter is inserted before a havoc breaking filter")
         public void shouldConfigureSecurity_withFilterPositioning() {
             RestTemplate allowedRestTemplate = buildRestTemplate(FilterPositioningBeforeConfig.ALLOWED_KEY);
-            RestTemplate forbiddenTemplate = buildRestTemplate("foo");
+            RestTemplate unauthorizedTemplate = buildRestTemplate("foo");
 
             // Configured key should be allowed, but returns "I am teapot" due to havoc breaking filter.
             HttpClientErrorException errorExceptionTeapot1 = assertThrows(HttpClientErrorException.class, () -> allowedRestTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class)));
 
-            // Foo key should reach the teapot filter as well, but since it is forbidden no key will be logged.
-            HttpClientErrorException errorExceptionForbidden1 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
-            HttpClientErrorException errorExceptionForbidden2 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, List.class));
-            HttpClientErrorException errorExceptionForbidden3 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
+            // Foo key should reach the teapot filter as well, but since it is unauthorized no key will be logged.
+            HttpClientErrorException errorExceptionUnauthorized1 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            HttpClientErrorException errorExceptionUnauthorized2 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, List.class));
+            HttpClientErrorException errorExceptionUnauthorized3 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
 
             assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionTeapot1.getStatusCode());
             assertEquals("I AM A TEAPOT AND AM USING KEY filter-position-before-1234567890 :D", errorExceptionTeapot1.getResponseBodyAsString());
-            assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionForbidden1.getStatusCode());
-            assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionForbidden1.getResponseBodyAsString());
-            assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionForbidden2.getStatusCode());
-            assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionForbidden2.getResponseBodyAsString());
-            assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionForbidden3.getStatusCode());
-            assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionForbidden3.getResponseBodyAsString());
+            assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionUnauthorized1.getStatusCode());
+            assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionUnauthorized1.getResponseBodyAsString());
+            assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionUnauthorized2.getStatusCode());
+            assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionUnauthorized2.getResponseBodyAsString());
+            assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionUnauthorized3.getStatusCode());
+            assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionUnauthorized3.getResponseBodyAsString());
         }
     }
 
@@ -200,15 +202,15 @@ public class ApiKeyAuthenticationConfigurerTest {
         @DisplayName("should always return bogus response, since our filter is positioned after the havoc-wreaking filter")
         public void shouldConfigureSecurity_withFilterPositioning() {
             RestTemplate allowedRestTemplate = buildRestTemplate(FilterPositioningAfterConfig.ALLOWED_KEY);
-            RestTemplate forbiddenTemplate = buildRestTemplate("foo");
+            RestTemplate unauthorizedTemplate = buildRestTemplate("foo");
 
             // Configured key should return "I am teapot" without setting authentication, due to havoc breaking filter being before api key filter.
             HttpClientErrorException errorExceptionTeapot1 = assertThrows(HttpClientErrorException.class, () -> allowedRestTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class)));
 
             // Foo key should also return teapot error, since the teapot error is generated before the API Key filter is reached (and execution stops there).
-            HttpClientErrorException errorExceptionTeapot2 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
-            HttpClientErrorException errorExceptionTeapot3 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, List.class));
-            HttpClientErrorException errorExceptionTeapot4 = assertThrows(HttpClientErrorException.class, () -> forbiddenTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
+            HttpClientErrorException errorExceptionTeapot2 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+            HttpClientErrorException errorExceptionTeapot3 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/private-api/users", HttpMethod.GET, null, List.class));
+            HttpClientErrorException errorExceptionTeapot4 = assertThrows(HttpClientErrorException.class, () -> unauthorizedTemplate.exchange(baseUrl + "/foo", HttpMethod.GET, null, String.class));
 
             assertEquals(HttpStatus.I_AM_A_TEAPOT, errorExceptionTeapot1.getStatusCode());
             assertEquals("I AM A TEAPOT AND AM USING KEY <<not set>> :D", errorExceptionTeapot1.getResponseBodyAsString());
@@ -231,6 +233,50 @@ public class ApiKeyAuthenticationConfigurerTest {
             assertNotNull(e);
 
             assertEquals("Either AddFilterBeforeClass or AddFilterAfterClass must be specified.", e.getMessage());
+        }
+    }
+
+    @Nested
+    class customAuthenticationEntryPointConfig extends ApiKeyScenarioTest.CustomAuthenticationEntryPointTest {
+
+        @Test
+        @DisplayName("should use custom AuthenticationEntryPoint if specified")
+        public void shouldConfigureSecurity_withAntPattern()  {
+            RestTemplate allowedRestTemplate = buildRestTemplate(CustomAuthenticationEntryPointConfig.ALLOWED_KEY);
+            RestTemplate notAllowedTemplate = buildRestTemplate("foo");
+
+            // Configured key should be allowed
+            HttpEntity<Map<String, Object>> successResult = allowedRestTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
+
+            // Foo key should be unauthorized
+            HttpClientErrorException errorExceptionUnauthorized = assertThrows(HttpClientErrorException.class, () -> notAllowedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+
+            assertEquals("hi", Objects.requireNonNull(successResult.getBody()).get("message"));
+
+            // The custom AuthenticationEntryPoint sets 'PAYMENT_REQUIRED' as status.
+            assertEquals(HttpStatus.PAYMENT_REQUIRED, errorExceptionUnauthorized.getStatusCode());
+        }
+    }
+
+    @Nested
+    class nullAuthenticationEntryPointConfig extends ApiKeyScenarioTest.NullAuthenticationEntryPointTest {
+
+        @Test
+        @DisplayName("should use Spring default AuthenticationEntryPoint if explicitly set to null")
+        public void shouldConfigureSecurity_withAntPattern()  {
+            RestTemplate allowedRestTemplate = buildRestTemplate(NullAuthenticationEntryPointConfig.ALLOWED_KEY);
+            RestTemplate notAllowedTemplate = buildRestTemplate("foo");
+
+            // Configured key should be allowed
+            HttpEntity<Map<String, Object>> successResult = allowedRestTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, ParameterizedTypeReference.forType(Map.class));
+
+            // Foo key should be unauthorized
+            HttpClientErrorException errorExceptionUnauthorized = assertThrows(HttpClientErrorException.class, () -> notAllowedTemplate.exchange(baseUrl + "/public-api/v1/hello", HttpMethod.GET, null, Map.class));
+
+            assertEquals("hi", Objects.requireNonNull(successResult.getBody()).get("message"));
+
+            // The current default of Spring Framework is to return 'FORBIDDEN' as status for failed logins.
+            assertEquals(HttpStatus.FORBIDDEN, errorExceptionUnauthorized.getStatusCode());
         }
     }
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyScenarioTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/ApiKeyScenarioTest.java
@@ -56,4 +56,18 @@ public class ApiKeyScenarioTest {
 
     }
 
+    @ExtendWith(SpringExtension.class)
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    @ActiveProfiles({ "unit-test", "custom-authentication-entry-point" })
+    public static class CustomAuthenticationEntryPointTest extends AbstractSpringTest {
+
+    }
+
+    @ExtendWith(SpringExtension.class)
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    @ActiveProfiles({ "unit-test", "null-authentication-entry-point" })
+    public static class NullAuthenticationEntryPointTest extends AbstractSpringTest {
+
+    }
+
 }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyAuthenticationManagerTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyAuthenticationManagerTest.java
@@ -39,6 +39,18 @@ public class ApiKeyAuthenticationManagerTest {
         }
 
         @Test
+        @DisplayName("should throw BadCredentialsException if the key is null / empty")
+        void shouldThrowForNullOrEmptyKey() {
+            ApiKeyAuthenticationManager authenticationManager = new ApiKeyAuthenticationManager(List.of("test2345"));
+
+            BadCredentialsException eNull = assertThrows(BadCredentialsException.class, () -> authenticationManager.authenticate(new PreAuthenticatedAuthenticationToken(new ApiKeyPrincipal(null), "N/A")));
+            BadCredentialsException eEmpty = assertThrows(BadCredentialsException.class, () -> authenticationManager.authenticate(new PreAuthenticatedAuthenticationToken(new ApiKeyPrincipal(""), "N/A")));
+
+            assertEquals("The API key was not found or not the expected value.", eNull.getMessage());
+            assertEquals("The API key was not found or not the expected value.", eEmpty.getMessage());
+        }
+
+        @Test
         @DisplayName("should throw BadCredentialsException if the principal is not an instance of ApiKeyPrincipal")
         void shouldThrowForInvalidPrincipal() {
             ApiKeyAuthenticationManager authenticationManager = new ApiKeyAuthenticationManager(List.of("test2345"));

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilterTest.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/authentication/ApiKeyRequestFilterTest.java
@@ -20,17 +20,21 @@ class ApiKeyRequestFilterTest {
     class getPreAuthenticatedPrincipal {
 
         @Test
-        @DisplayName("should return null for missing / empty header")
-        void shouldReturnNull_forMissingOrEmptyHeader() {
+        @DisplayName("should return api key principal without key for missing / empty header")
+        void shouldReturnPrincipalWithoutKey_forMissingOrEmptyHeader() {
             String headerName = "foobar";
 
             MockHttpServletRequest request = new MockHttpServletRequest();
 
-            assertNull(new ApiKeyRequestFilter(headerName).getPreAuthenticatedPrincipal(request));
+            Object principal = new ApiKeyRequestFilter(headerName).getPreAuthenticatedPrincipal(request);
+            assertInstanceOf(ApiKeyPrincipal.class, principal);
+            assertNull(((ApiKeyPrincipal)principal).apiKey());
 
             request.addHeader(headerName, "");
 
-            assertNull(new ApiKeyRequestFilter(headerName).getPreAuthenticatedPrincipal(request));
+            principal = new ApiKeyRequestFilter(headerName).getPreAuthenticatedPrincipal(request);
+            assertInstanceOf(ApiKeyPrincipal.class, principal);
+            assertEquals("", ((ApiKeyPrincipal)principal).apiKey());
 
             request = new MockHttpServletRequest();
             request.addHeader(headerName, "test");
@@ -47,7 +51,7 @@ class ApiKeyRequestFilterTest {
             request.addHeader(headerName, apiKey);
             Object principal = new ApiKeyRequestFilter(headerName).getPreAuthenticatedPrincipal(request);
 
-            assertTrue(principal instanceof ApiKeyPrincipal);
+            assertInstanceOf(ApiKeyPrincipal.class, principal);
 
             assertEquals(apiKey, ((ApiKeyPrincipal)principal).apiKey());
         }

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/CustomAuthenticationEntryPointConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/CustomAuthenticationEntryPointConfig.java
@@ -1,0 +1,36 @@
+package nl._42.apikeyauthentication.autoconfigure.test;
+
+import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfiguration;
+import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
+import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+import java.util.Set;
+
+@Configuration
+@Profile("custom-authentication-entry-point")
+@EnableWebSecurity
+public class CustomAuthenticationEntryPointConfig {
+
+    public static final String ALLOWED_KEY = "custom-aep-1234567890";
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
+                .authorizedApiKeys(Set.of(ALLOWED_KEY))
+                // custom authenticationFailureEntryPoint which sets Http 402 'Payment Required' as status.
+                .authenticationFailureEntryPoint(new HttpStatusEntryPoint(HttpStatus.PAYMENT_REQUIRED))
+                .build();
+
+        ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
+    }
+}

--- a/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/NullAuthenticationEntryPointConfig.java
+++ b/src/test/java/nl/_42/apikeyauthentication/autoconfigure/test/NullAuthenticationEntryPointConfig.java
@@ -1,0 +1,34 @@
+package nl._42.apikeyauthentication.autoconfigure.test;
+
+import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfiguration;
+import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurationBuilder;
+import nl._42.apikeyauthentication.autoconfigure.ApiKeyAuthenticationConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Set;
+
+@Configuration
+@Profile("null-authentication-entry-point")
+@EnableWebSecurity
+public class NullAuthenticationEntryPointConfig {
+
+    public static final String ALLOWED_KEY = "null-aep-1234567890";
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        ApiKeyAuthenticationConfiguration config = ApiKeyAuthenticationConfigurationBuilder.builder()
+                .authorizedApiKeys(Set.of(ALLOWED_KEY))
+                // by deliberately assigning authenticationFailureEntryPoint to null, we use the defaults from Spring.
+                .authenticationFailureEntryPoint(null)
+                .build();
+
+        ApiKeyAuthenticationConfigurer.configure(config, http);
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
- Spring returns HTTP 403 'Forbidden' by default for failing authentications.
- This seems not to be according the HTTP convention for api keys, so
  we return 401 instead.
- Added te ability to return a custom HTTP status, or keep
  the default of Spring by explicitly setting `AuthenticationEntryPoint`
  to null.
- Return a ApiKeyPrincipal for null / empty keys, so authentication is
  properly delegated to the `ApiKeyAuthenticationManager` to verify authentication.